### PR TITLE
Require tokio's "stream" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.1.1"
 once_cell = "1.4"
 pin-project-lite = "0.1"
 tokio_02 = {version = "0.2.22", package = "tokio", features = ["rt-threaded"]}
-tokio = {version = "0.3"}
+tokio = {version = "0.3", features = ["stream"]}
 bytes = "0.5.6"
 
 [dev-dependencies]


### PR DESCRIPTION
Basically, `tokio-compat-02` doesnt build without this feature enabled. While testing locally, `dev-dependencies` are being used, so it is easy to miss. If you try removing the `dev-dependencies` section and run `cargo build`, you'll see

```
error[E0432]: unresolved import `tokio::stream`
 --> src/io.rs:9:12
  |
9 | use tokio::stream::Stream;
  |            ^^^^^^ could not find `stream` in `tokio`
```